### PR TITLE
Feature/#11 → Use _FSM_ for the main dynamic supervisor

### DIFF
--- a/lib/siblings.ex
+++ b/lib/siblings.ex
@@ -120,7 +120,7 @@ defmodule Siblings do
   end
 
   @doc false
-  @spec lookup(module(), true | false | :name | :never) :: nil | pid()
+  @spec lookup(module(), true | false | :name | :never) :: nil | pid() | atom()
   def lookup(name \\ default_fqn(), try_cached? \\ true)
 
   def lookup(_name, :never), do: nil

--- a/lib/siblings.ex
+++ b/lib/siblings.ex
@@ -20,6 +20,13 @@ defmodule Siblings do
 
   @default_interval Application.compile_env(:siblings, :perform_interval, 5_000)
 
+  @type worker :: %{
+          module: module(),
+          id: Worker.id(),
+          payload: Worker.payload(),
+          options: InternalWorker.options()
+        }
+
   @doc """
   Starts the supervision subtree, holding the `PartitionSupervisor`.
   """
@@ -32,34 +39,48 @@ defmodule Siblings do
 
     {workers, opts} = Keyword.pop(opts, :workers, [])
 
-    Siblings
-    |> Supervisor.start_link(opts, name: sup_fqn(name))
-    |> tap(fn _ ->
-      Enum.each(workers, fn {worker, opts} ->
-        {id, opts} = Keyword.pop(opts, :id, worker)
-        {interval, opts} = Keyword.pop(opts, :interval, @default_interval)
-        {hibernate?, opts} = Keyword.pop(opts, :hibernate?, false)
-        state = Map.new(opts)
+    workers =
+      Enum.map(workers, fn
+        %{module: _, id: _} = worker ->
+          worker
 
-        Siblings.start_child(worker, id, state,
-          name: name,
-          hibernate?: hibernate?,
-          interval: interval
-        )
+        {worker, opts} ->
+          {id, opts} = Keyword.pop(opts, :id, worker)
+          {interval, opts} = Keyword.pop(opts, :interval, @default_interval)
+          {hibernate?, opts} = Keyword.pop(opts, :hibernate?, false)
+
+          %{
+            id: id,
+            module: worker,
+            payload: Map.new(opts),
+            options: [name: name, hibernate?: hibernate?, interval: interval]
+          }
       end)
-    end)
+
+    result = Supervisor.start_link(Siblings, opts, name: sup_fqn(name))
+
+    case lookup(name) do
+      pid when is_pid(pid) -> GenServer.cast(pid, {:initialize, %{start: workers}})
+      # start_workers(workers)
+      nil -> nil
+    end
+
+    result
   end
 
   @doc false
   @impl Supervisor
   def init(opts) do
     {name, opts} = Keyword.pop(opts, :name, default_fqn())
-    {lookup, _opts} = Keyword.pop(opts, :lookup, :agent)
+    {lookup, _opts} = Keyword.pop(opts, :lookup, true)
 
     lookup =
       case lookup do
-        :agent -> [{Lookup, name: name}]
-        _ -> []
+        true ->
+          [{Lookup, payload: %{name: lookup_fqn(name), siblings: name}, name: lookup_fqn(name)}]
+
+        _ ->
+          []
       end
 
     children = [
@@ -76,7 +97,7 @@ defmodule Siblings do
   Useful when many `Siblings` processes are running simultaneously.
   """
   @spec child_spec([
-          {:name, module()} | {:lookup, :none | :agent | :fsm} | {:id, any()} | keyword()
+          {:name, module()} | {:lookup, boolean() | module()} | {:id, any()} | keyword()
         ]) ::
           Supervisor.child_spec()
   def child_spec(opts) do
@@ -84,19 +105,42 @@ defmodule Siblings do
     %{id: id, start: {Siblings, :start_link, [opts]}}
   end
 
+  @doc """
+  Returns the state of the `Siblings` instance.
+  """
+  @spec state(module()) :: nil | Finitomata.State.t()
+  def state(name \\ default_fqn()) do
+    name
+    |> lookup()
+    |> case do
+      pid when is_pid(pid) -> GenServer.call(pid, :state)
+      nil -> nil
+    end
+  end
+
   @doc false
-  @spec lookup(module(), boolean()) :: nil | pid() | atom()
+  @spec lookup(module(), boolean() | :never) :: nil | pid()
   def lookup(name \\ default_fqn(), try_cached? \\ true)
+
+  def lookup(_name, :never), do: nil
 
   def lookup(name, false) do
     name
     |> sup_fqn()
-    |> Supervisor.which_children()
-    |> Enum.find(&match?({_name, _pid, :worker, [mod]} when mod in [Lookup, Fsm], &1))
-    |> then(fn
-      {_name, pid, :worker, _} -> pid
-      _ -> nil
-    end)
+    |> Process.whereis()
+    |> case do
+      pid when is_pid(pid) ->
+        pid
+        |> Supervisor.which_children()
+        |> Enum.find(&match?({_name, _pid, :worker, [Lookup]}, &1))
+        |> case do
+          {_name, pid, :worker, _} -> pid
+          nil -> nil
+        end
+
+      nil ->
+        nil
+    end
   end
 
   def lookup(name, true) do
@@ -104,8 +148,10 @@ defmodule Siblings do
 
     fqn
     |> Process.whereis()
-    |> is_pid()
-    |> if(do: fqn, else: lookup(name, false))
+    |> case do
+      pid when is_pid(pid) -> pid
+      _ -> lookup(name, false)
+    end
   end
 
   @doc false
@@ -121,8 +167,8 @@ defmodule Siblings do
   @doc """
   Returns the state of the named worker.
   """
-  @spec state(module(), Worker.id()) :: State.t()
-  def state(name \\ default_fqn(), id) do
+  @spec worker_state(module(), Worker.id()) :: State.t()
+  def worker_state(name \\ default_fqn(), id) do
     name
     |> pid(id)
     |> InternalWorker.state()
@@ -133,7 +179,7 @@ defmodule Siblings do
   """
   @spec payload(module(), Worker.id()) :: Worker.payload()
   def payload(name \\ default_fqn(), id) do
-    with {_ref, pid} <- state(name, id).fsm,
+    with {_ref, pid} <- worker_state(name, id).fsm,
          do: GenServer.call(pid, :state).payload
   end
 
@@ -204,26 +250,43 @@ defmodule Siblings do
   Starts the supervised child under the `PartitionSupervisor`.
   """
   @spec start_child(module(), Worker.id(), Worker.payload(), InternalWorker.options()) ::
-          DynamicSupervisor.on_start_child()
+          :ok | DynamicSupervisor.on_start_child()
   def start_child(worker, id, payload, opts \\ []) do
     {name, opts} = Keyword.pop(opts, :name, default_fqn())
 
-    case find_child(name, id, true) do
+    do_start_child(
+      name,
+      %{module: worker, id: id, payload: payload, options: opts},
+      lookup?(name)
+    )
+  end
+
+  @spec do_start_child(module() | nil, worker(), boolean()) ::
+          :ok | DynamicSupervisor.on_start_child()
+  defp do_start_child(name, worker, true) do
+    Lookup.put(name, worker)
+  end
+
+  defp do_start_child(name, worker, false) do
+    case find_child(name, worker.id, false) do
       {pid, _child} ->
         {:error, {:already_started, pid}}
 
       nil ->
-        {shutdown, opts} = Keyword.pop(opts, :shutdown, 5_000)
+        {shutdown, opts} = Keyword.pop(worker.options, :shutdown, 5_000)
         opts = Keyword.put(opts, :lookup, Siblings.lookup(name))
 
         spec = %{
-          id: Enum.join([worker, id], ":"),
-          start: {InternalWorker, :start_link, [worker, id, payload, opts]},
+          id: Enum.join([worker.module, worker.id], ":"),
+          start: {InternalWorker, :start_link, [worker.module, worker.id, worker.payload, opts]},
           restart: :transient,
           shutdown: shutdown
         }
 
-        DynamicSupervisor.start_child({:via, PartitionSupervisor, {name, {worker, id}}}, spec)
+        DynamicSupervisor.start_child(
+          {:via, PartitionSupervisor, {name, {worker.module, worker.id}}},
+          spec
+        )
     end
   end
 
@@ -261,11 +324,11 @@ defmodule Siblings do
   @doc """
   Returns the list of currently managed children.
   """
-  @spec children(:pids | :states | :map, module(), boolean()) :: [State.t()]
+  @spec children(:pids | :states | :map | :id_pids, module(), boolean() | :never) :: [State.t()]
   def children(type \\ :states, name \\ default_fqn(), try_cached? \\ true),
     do: do_children(type, lookup(name, try_cached?), name)
 
-  @spec do_children(:pids | :states | :map, nil | pid() | atom(), module()) ::
+  @spec do_children(:pids | :states | :map | :id_pids, nil | pid() | atom(), module()) ::
           [State.t()] | [pid]
   defp do_children(:map, nil, name) do
     for state <- do_children(:states, nil, name), into: %{}, do: {state.id, state}
@@ -286,11 +349,14 @@ defmodule Siblings do
     for {_id, pid} <- Lookup.all(lookup), do: pid
   end
 
-  defp do_children(:states, nil, name),
-    do: :pids |> do_children(nil, name) |> Enum.map(&InternalWorker.state/1)
-
   defp do_children(:states, lookup, name) when is_pid(lookup) or is_atom(lookup),
     do: :pids |> do_children(lookup, name) |> Enum.map(&InternalWorker.state/1)
+
+  defp do_children(:id_pids, lookup, name) when is_pid(lookup) or is_atom(lookup) do
+    for pid <- do_children(:pids, lookup, name), into: %{} do
+      {InternalWorker.state(pid).id, pid}
+    end
+  end
 
   @spec default_fqn :: module()
   @doc false
@@ -303,5 +369,5 @@ defmodule Siblings do
   @spec lookup_fqn(pid() | module()) :: module()
   def lookup_fqn(name_or_pid \\ default_fqn())
   def lookup_fqn(pid) when is_pid(pid), do: pid
-  def lookup_fqn(name), do: Module.concat(name, Lookup)
+  def lookup_fqn(name), do: Module.concat([name, "Lookup"])
 end

--- a/lib/siblings/internal_worker.ex
+++ b/lib/siblings/internal_worker.ex
@@ -117,7 +117,6 @@ defmodule Siblings.InternalWorker do
   @impl GenServer
   def init(%State{} = state) do
     state = start_fsm(state)
-    update_lookup(:put, state.lookup, state.id)
     {:ok, %State{state | schedule: schedule_work(state.interval)}}
   end
 
@@ -198,7 +197,7 @@ defmodule Siblings.InternalWorker do
   @doc false
   @impl GenServer
   def terminate(:normal, state),
-    do: update_lookup(:del, state.lookup, state.id)
+    do: update_lookup(state.lookup, state.id)
 
   @impl GenServer
   def terminate(_, state),
@@ -229,10 +228,9 @@ defmodule Siblings.InternalWorker do
   end
 
   @doc false
-  @spec update_lookup(:put | :del, nil | GenServer.name(), W.id()) :: :ok
-  defp update_lookup(_action, nil, _id), do: :ok
-  defp update_lookup(:put, lookup, id), do: Siblings.Lookup.put(lookup, id, self())
-  defp update_lookup(:del, lookup, id), do: Siblings.Lookup.del(lookup, id)
+  @spec update_lookup(nil | GenServer.name(), W.id()) :: :ok
+  defp update_lookup(nil, _id), do: :ok
+  defp update_lookup(lookup, id), do: Siblings.Lookup.del(lookup, id)
 
   @doc false
   if T.enabled?(), do: @telemetria(level: :info)

--- a/lib/siblings/lookup.ex
+++ b/lib/siblings/lookup.ex
@@ -20,10 +20,12 @@ defmodule Siblings.Lookup do
   def on_transition(:idle, :initialize, payload, state) do
     children = Siblings.children(:id_pids, state[:siblings], :never)
 
-    workers =
+    state = Map.put_new(state, :workers, children)
+
+    state =
       payload
       |> Map.get(:start, [])
-      |> Enum.reduce(children, fn payload, acc ->
+      |> Enum.reduce(state, fn payload, acc ->
         # [AM] Doc + Log on failures
         case on_transition(:ready, :start_child, payload, acc) do
           {:ok, :ready, acc} -> acc
@@ -31,7 +33,7 @@ defmodule Siblings.Lookup do
         end
       end)
 
-    {:ok, :ready, Map.put(state, :workers, workers)}
+    {:ok, :ready, state}
   end
 
   @impl Finitomata

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Siblings.MixProject do
 
   defp deps do
     [
-      {:finitomata, "~> 0.4"},
+      {:finitomata, "~> 0.5"},
       {:telemetria, "~> 0.12", optional: true},
       {:boundary, "~> 0.9", runtime: false},
       # dev / test

--- a/test/siblings_test.exs
+++ b/test/siblings_test.exs
@@ -17,23 +17,15 @@ defmodule SiblingsTest do
         )
     }
 
-    # on_exit(fn -> Process.sleep(100) end)
+    # on_exit(fn -> Process.sleep(1_000) end)
   end
 
   test "Worker with FSM" do
-    {:ok, pid} =
-      Siblings.start_child(Siblings.Test.Worker, "MyWorker", %{pid: self()},
-        name: MySiblings,
-        hibernate?: true,
-        interval: 200
-      )
-
-    assert {:error, {:already_started, ^pid}} =
-             Siblings.start_child(Siblings.Test.Worker, "MyWorker", %{pid: self()},
-               name: MySiblings,
-               hibernate?: true,
-               interval: 200
-             )
+    Siblings.start_child(Siblings.Test.Worker, "MyWorker", %{pid: self()},
+      name: MySiblings,
+      hibernate?: true,
+      interval: 200
+    )
 
     assert [%Siblings.InternalWorker.State{id: "MyWorker"}] =
              Siblings.children(:states, MySiblings)
@@ -44,19 +36,15 @@ defmodule SiblingsTest do
     assert_receive :s1_s2, 1_000
     assert_receive :s2_end, 1_000
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert [] == Siblings.children(:states, MySiblings)
   end
 
   test "Worker-FSM" do
-    {:ok, pid} =
-      Siblings.start_child(Siblings.Test.WorkerFSM, "MyWorkerFSM", %{pid: self()}, interval: 200)
+    Siblings.start_child(Siblings.Test.WorkerFSM, "MyWorkerFSM", %{pid: self()}, interval: 200)
 
-    assert {:error, {:already_started, ^pid}} =
-             Siblings.start_child(Siblings.Test.Worker, "MyWorkerFSM", %{pid: self()},
-               interval: 200
-             )
+    pid = Siblings.find_child("MyWorkerFSM")
 
     assert [%Siblings.InternalWorker.State{id: "MyWorkerFSM"}] = Siblings.children()
 
@@ -70,17 +58,14 @@ defmodule SiblingsTest do
 
     assert_receive :s3_end, 1_000
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert [] == Siblings.children()
   end
 
   test "#multi_transition/3" do
-    {:ok, _pid1} =
-      Siblings.start_child(Siblings.Test.NoPerform, "NoPerform1", %{pid: self()}, interval: 60_000)
-
-    {:ok, _pid2} =
-      Siblings.start_child(Siblings.Test.NoPerform, "NoPerform2", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.NoPerform, "NoPerform1", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.NoPerform, "NoPerform2", %{pid: self()}, interval: 60_000)
 
     Siblings.multi_transition(:to_s2, nil)
 
@@ -93,17 +78,14 @@ defmodule SiblingsTest do
     assert_receive :s3_end
     assert_receive :s3_end
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert [] == Siblings.children()
   end
 
   test "#call/3" do
-    {:ok, _pid1} =
-      Siblings.start_child(Siblings.Test.NoPerform, "Callable1", %{pid: self()}, interval: 60_000)
-
-    {:ok, _pid2} =
-      Siblings.start_child(Siblings.Test.Callable, "Callable2", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.NoPerform, "Callable1", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.Callable, "Callable2", %{pid: self()}, interval: 60_000)
 
     assert {:error, :callback_not_implemented} == Siblings.call("Callable1", 42)
     assert 84 == Siblings.call("Callable2", 42)
@@ -112,17 +94,14 @@ defmodule SiblingsTest do
     Siblings.multi_transition(:to_s3, nil)
     Siblings.multi_transition(:__end__, nil)
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert [] == Siblings.children()
   end
 
   test "#multi_call/2" do
-    {:ok, _pid1} =
-      Siblings.start_child(Siblings.Test.NoPerform, "Callable1", %{pid: self()}, interval: 60_000)
-
-    {:ok, _pid2} =
-      Siblings.start_child(Siblings.Test.Callable, "Callable2", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.NoPerform, "Callable1", %{pid: self()}, interval: 60_000)
+    Siblings.start_child(Siblings.Test.Callable, "Callable2", %{pid: self()}, interval: 60_000)
 
     assert [84, {:error, :callback_not_implemented}] == Enum.sort(Siblings.multi_call(42))
 
@@ -130,7 +109,7 @@ defmodule SiblingsTest do
     Siblings.multi_transition(:to_s3, nil)
     Siblings.multi_transition(:__end__, nil)
 
-    Process.sleep(100)
+    Process.sleep(200)
 
     assert [] == Siblings.children()
   end

--- a/test/siblings_test.exs
+++ b/test/siblings_test.exs
@@ -44,7 +44,7 @@ defmodule SiblingsTest do
   test "Worker-FSM" do
     Siblings.start_child(Siblings.Test.WorkerFSM, "MyWorkerFSM", %{pid: self()}, interval: 200)
 
-    pid = Siblings.find_child("MyWorkerFSM")
+    {pid, _} = Siblings.find_child(Siblings, "MyWorkerFSM", true)
 
     assert [%Siblings.InternalWorker.State{id: "MyWorkerFSM"}] = Siblings.children()
 


### PR DESCRIPTION
This is needed to expose the whole `Siblings` tree to the generated consumer based solely on _FSM_ instances.